### PR TITLE
Add DETableRow component with bolder row highlight

### DIFF
--- a/src/__tests__/deTableRow.js
+++ b/src/__tests__/deTableRow.js
@@ -1,0 +1,16 @@
+import React from "react";
+import ReactDOM from "react-dom";
+
+import { getMuiTheme, MuiThemeProvider } from "../lib";
+import DETableRowTest from "../../stories/DETableRow.stories";
+
+it("renders DETableRow without crashing", () => {
+    const div = document.createElement("div");
+    ReactDOM.render(
+        <MuiThemeProvider theme={getMuiTheme()}>
+            <DETableRowTest />
+        </MuiThemeProvider>,
+        div
+    );
+    ReactDOM.unmountComponentAtNode(div);
+});

--- a/src/lib.js
+++ b/src/lib.js
@@ -54,6 +54,7 @@ import DEPromptDialog from "./util/dialog/DEPromptDialog";
 
 import ErrorExpansionPanel from "./util/ErrorExpansionPanel";
 import ErrorHandler from "./util/ErrorHandler";
+import DECheckbox from "./util/table/DECheckbox";
 import EmptyTable from "./util/table/EmptyTable";
 import EnhancedTableHead from "./util/table/EnhancedTableHead";
 
@@ -92,6 +93,7 @@ export {
     dateConstants,
     CyVerseAnnouncer,
     DEAlertDialog,
+    DECheckbox,
     DEConfirmationDialog,
     DEDialogHeader,
     DEPromptDialog,

--- a/src/lib.js
+++ b/src/lib.js
@@ -55,6 +55,7 @@ import DEPromptDialog from "./util/dialog/DEPromptDialog";
 import ErrorExpansionPanel from "./util/ErrorExpansionPanel";
 import ErrorHandler from "./util/ErrorHandler";
 import DECheckbox from "./util/table/DECheckbox";
+import DETableRow from "./util/table/DETableRow";
 import EmptyTable from "./util/table/EmptyTable";
 import EnhancedTableHead from "./util/table/EnhancedTableHead";
 
@@ -98,6 +99,7 @@ export {
     DEDialogHeader,
     DEPromptDialog,
     DEHyperlink,
+    DETableRow,
     EmptyTable,
     EnhancedTableHead,
     ErrorExpansionPanel,

--- a/src/util/table/DECheckbox.js
+++ b/src/util/table/DECheckbox.js
@@ -1,0 +1,19 @@
+/**
+ * @author aramsey
+ *
+ * A regular MUI Checkbox but using the theme's primary color
+ */
+import React from "react";
+import { Checkbox } from "@material-ui/core";
+
+function DECheckbox(props) {
+    const { children } = props;
+
+    return (
+        <Checkbox color="primary" {...props}>
+            {children}
+        </Checkbox>
+    );
+}
+
+export default DECheckbox;

--- a/src/util/table/DETableRow.js
+++ b/src/util/table/DETableRow.js
@@ -1,0 +1,41 @@
+import React from "react";
+
+import { makeStyles, TableRow } from "@material-ui/core";
+import { palette } from "../../lib";
+
+/**
+ * This style was copied from MUI's TableRow style and updated to have the selected and hover colors
+ * stand out more clearly
+ * https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/TableRow/TableRow.js
+ */
+const useStyles = makeStyles((theme) => ({
+    root: {
+        "&$selected": {
+            backgroundColor:
+                theme.palette.type === "light"
+                    ? palette.lightBlue
+                    : "rgba(255, 255, 255, 0.16)",
+        },
+        "&$hover:hover": {
+            backgroundColor:
+                theme.palette.type === "light"
+                    ? "rgba(0, 0, 0, 0.13)"
+                    : "rgba(255, 255, 255, 0.28)",
+        },
+    },
+    selected: {},
+    hover: {},
+}));
+
+function DETableRow(props) {
+    const { children } = props;
+    const classes = useStyles();
+
+    return (
+        <TableRow classes={classes} {...props}>
+            {children}
+        </TableRow>
+    );
+}
+
+export default DETableRow;

--- a/stories/DETableRow.stories.js
+++ b/stories/DETableRow.stories.js
@@ -1,0 +1,46 @@
+import React, { Component } from "react";
+
+import DETableRow from "../src/util/table/DETableRow";
+
+import { Table, TableBody, TableCell } from "@material-ui/core";
+import { storiesOf } from "@storybook/react";
+import DECheckbox from "../src/util/table/DECheckbox";
+
+export default class DETableRowTest extends Component {
+    render() {
+        return (
+            <Table>
+                <TableBody>
+                    <DETableRow hover>
+                        <TableCell>
+                            <DECheckbox checked={false} />
+                        </TableCell>
+                        <TableCell>Cell1</TableCell>
+                        <TableCell>Cell2</TableCell>
+                        <TableCell>Cell3</TableCell>
+                    </DETableRow>
+                    <DETableRow hover selected={true}>
+                        <TableCell>
+                            <DECheckbox checked={true} />
+                        </TableCell>
+                        <TableCell>This</TableCell>
+                        <TableCell>row's</TableCell>
+                        <TableCell>selected</TableCell>
+                    </DETableRow>
+                    <DETableRow hover>
+                        <TableCell>
+                            <DECheckbox checked={false} />
+                        </TableCell>
+                        <TableCell>Cell1</TableCell>
+                        <TableCell>Cell2</TableCell>
+                        <TableCell>Cell3</TableCell>
+                    </DETableRow>
+                </TableBody>
+            </Table>
+        );
+    }
+}
+
+storiesOf("DETableRow", module).add("with sample data", () => (
+    <DETableRowTest />
+));


### PR DESCRIPTION
`DECheckbox` will use CyVerse's dark blue and `DETableRow` will use CyVerse's light blue for selected rows

Before:
![image](https://user-images.githubusercontent.com/8909156/66354577-2030c780-e91a-11e9-94b4-d9493879566b.png)

After:
![image](https://user-images.githubusercontent.com/8909156/66354570-173ff600-e91a-11e9-80be-6df953f7d2e0.png)
