### PR TITLE
New ui-lib theme

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -2,7 +2,8 @@ import React from "react";
 import { addDecorator, configure } from "@storybook/react";
 import { withConsole } from "@storybook/addon-console";
 import { withKnobs } from "@storybook/addon-knobs";
-import { getMuiTheme, MuiThemeProvider } from "../src/lib";
+import { getMuiTheme } from "../src/lib";
+import { MuiThemeProvider } from "@material-ui/core/styles";
 
 //redirect console error / logs / warns to action logger
 addDecorator((storyFn, context) => withConsole()(storyFn)(context));

--- a/src/lib.js
+++ b/src/lib.js
@@ -35,7 +35,6 @@ import {
 } from "./util/FormField";
 import getRegExp from "./util/getRegExp";
 import hasProps from "./util/hasProps";
-import palette from "./util/CyVersePalette";
 import {
     getMessage,
     formatMessage,
@@ -59,25 +58,8 @@ import EnhancedTableHead from "./util/table/EnhancedTableHead";
 import TablePaginationActions from "./util/table/TablePaginationActions";
 import { stableSort, getSorting } from "./util/table/TableSort";
 
-import { createMuiTheme, MuiThemeProvider } from "@material-ui/core/styles";
-
-const getMuiTheme = (theme) =>
-    createMuiTheme({
-        palette: {
-            primary: {
-                main: palette.blue,
-            },
-            secondary: {
-                main: palette.lightBlue,
-            },
-        },
-        typography: {
-            button: {
-                textTransform: "none",
-            },
-            useNextVariants: true,
-        },
-    });
+import { MuiThemeProvider } from "@material-ui/core/styles";
+import getMuiTheme from "./util/CyVerseTheme";
 
 export {
     announce,
@@ -122,7 +104,6 @@ export {
     Highlighter,
     LoadingMask,
     MuiThemeProvider,
-    palette,
     QuickLaunch,
     Rate,
     SearchField,

--- a/src/lib.js
+++ b/src/lib.js
@@ -58,7 +58,6 @@ import EnhancedTableHead from "./util/table/EnhancedTableHead";
 import TablePaginationActions from "./util/table/TablePaginationActions";
 import { stableSort, getSorting } from "./util/table/TableSort";
 
-import { MuiThemeProvider } from "@material-ui/core/styles";
 import getMuiTheme from "./util/CyVerseTheme";
 
 export {
@@ -103,7 +102,6 @@ export {
     hasProps,
     Highlighter,
     LoadingMask,
-    MuiThemeProvider,
     QuickLaunch,
     Rate,
     SearchField,

--- a/src/util/CyVersePalette.js
+++ b/src/util/CyVersePalette.js
@@ -1,4 +1,4 @@
-export default {
+const oldPalette = {
     orange: "#f19e1f", // 241, 158, 31
     lightGreen: "#97af3c", // 151, 175, 60
     darkGreen: "#5c8727", // 92, 135, 39
@@ -11,4 +11,29 @@ export default {
     darkestBlue: "#142248", // 20, 34, 72
     white: "#ffffff",
     red: "#e60424",
+};
+
+const newPalette = {
+    white: "#ffffff",
+    lightSilver: "#e2e2e2",
+    silver: "#a5a4a4",
+    blueGrey: "#525A68",
+    black: "#000000",
+    darkNavy: "#142248",
+    navy: "#004471",
+    cobalt: "#0971AB", // primary
+    sky: "#99D9EA",
+    yellow: "#F7D21E",
+    gold: "#F8981D",
+    redSun: "#F1592B",
+    violet: "#AA2173",
+    indigo: "#4A2E8D",
+    leaf: "#378F43",
+    grass: "#7CB342",
+};
+
+// Merge the two palettes for now. We'll eventually remove the old palette.
+export default {
+    ...oldPalette,
+    ...newPalette,
 };

--- a/src/util/CyVerseTheme.js
+++ b/src/util/CyVerseTheme.js
@@ -1,0 +1,48 @@
+import { createMuiTheme } from "@material-ui/core/styles";
+import palette from "./CyVersePalette";
+
+/**
+ * Creates and returns a new theme. If an existing theme object is passed in,
+ * it will be merged with the ui-lib theme.
+ *
+ * @param {object} theme - A theme to override/add on to the default ui-lib theme.
+ * @returns {object}
+ */
+export default (theme) =>
+    createMuiTheme(
+        {
+            palette: {
+                type: "light",
+
+                // All intentions should be defined with references to colors from the new palette.
+                primary: {
+                    main: palette.cobalt,
+                },
+                secondary: {
+                    main: palette.sky,
+                },
+                error: {
+                    main: palette.redSun,
+                },
+                warning: {
+                    main: palette.yellow,
+                },
+                info: {
+                    main: palette.silver,
+                },
+                success: {
+                    main: palette.grass,
+                },
+
+                ...palette, // allow all of the colors to be referenced in the palette.
+            },
+            typography: {
+                button: {
+                    textTransform: "none",
+                },
+                useNextVariants: true,
+            },
+        },
+
+        theme || {} // Allow callers to override/add to the theme with their own values.
+    );

--- a/src/util/table/DETableRow.js
+++ b/src/util/table/DETableRow.js
@@ -1,7 +1,7 @@
 import React from "react";
 
 import { makeStyles, TableRow } from "@material-ui/core";
-import { palette } from "../../lib";
+import palette from "../CyVersePalette";
 
 /**
  * This style was copied from MUI's TableRow style and updated to have the selected and hover colors


### PR DESCRIPTION
This adds the new colors to the palette and provides a default, override-able theme that can be used outside of the library.

The new palette consists of the old and new color schemes for now, until the components in ui-lib can be converted over to using the theme rather than accessing the palette directly.

Callers are no longer able to reference the palette object outside of ui-lib. They should use the theme returned by the default exported function from `src/util/CyVerseTheme.js`. This is a breaking change that will require a major version bump.

Callers are no longer able to import the MuiThemeProvider from ui-lib directly. They should import it from material-ui directly. This also requires a major version bump.