### PR TITLE
Add babel-plugin-transform-imports again, hopefully better

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,7 @@
 {
   "presets": ["@babel/preset-env", "@babel/preset-react"],
-  "plugins": ["@babel/plugin-proposal-class-properties"]
+  "plugins": ["@babel/plugin-proposal-class-properties",
+              ["babel-plugin-transform-imports",
+               {"@material-ui/core": {"transform": '@material-ui/core/esm/${member}', 'preventFullImport': true},
+                "@material-ui/icons": {"transform": '@material-ui/icons/esm/${member}', 'preventFullImport': true}}]]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7344,6 +7344,16 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
             "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
         },
+        "babel-plugin-transform-imports": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-imports/-/babel-plugin-transform-imports-2.0.0.tgz",
+            "integrity": "sha512-65ewumYJ85QiXdcB/jmiU0y0jg6eL6CdnDqQAqQ8JMOKh1E52VPG3NJzbVKWcgovUR5GBH8IWpCXQ7I8Q3wjgw==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.4",
+                "is-valid-path": "^0.1.1"
+            }
+        },
         "babel-plugin-transform-inline-consecutive-adds": {
             "version": "0.4.3",
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-inline-consecutive-adds/-/babel-plugin-transform-inline-consecutive-adds-0.4.3.tgz",
@@ -12640,6 +12650,32 @@
             "integrity": "sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU=",
             "dev": true
         },
+        "is-invalid-path": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/is-invalid-path/-/is-invalid-path-0.1.0.tgz",
+            "integrity": "sha1-MHqFWzzxqTi0TqcNLGEQYFNxTzQ=",
+            "dev": true,
+            "requires": {
+                "is-glob": "^2.0.0"
+            },
+            "dependencies": {
+                "is-extglob": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+                    "dev": true
+                },
+                "is-glob": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "^1.0.0"
+                    }
+                }
+            }
+        },
         "is-map": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.1.tgz",
@@ -12778,6 +12814,15 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
             "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+        },
+        "is-valid-path": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/is-valid-path/-/is-valid-path-0.1.1.tgz",
+            "integrity": "sha1-EQ+f90w39mPh7HkV60UfLbk6yd8=",
+            "dev": true,
+            "requires": {
+                "is-invalid-path": "^0.1.0"
+            }
         },
         "is-window": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
         "@storybook/react": "^5.2.8",
         "@storybook/storybook-deployer": "^2.8.1",
         "babel-loader": "^8.0.6",
+        "babel-plugin-transform-imports": "^2.0.0",
         "css-loader": "^2.1.1",
         "formik": "^1.5.8",
         "husky": "^1.3.1",


### PR DESCRIPTION
Putting this up so folks can mess with it, this is following the recommendations on https://material-ui.com/guides/minimizing-bundle-size/

It only affects @material-ui/core right now since I fixed the one icons one manually before.