### PR TITLE
Use lighter date-formatting code

### DIFF
--- a/src/util/DateFormatter.js
+++ b/src/util/DateFormatter.js
@@ -2,10 +2,9 @@
  @author sriram
  */
 
-import { format } from "date-fns";
+import lightFormat from "date-fns/lightFormat";
+import toDate from "date-fns/toDate";
 import dateConstants from "../dateConstants";
-
-import { legacyParse } from "@date-fns/upgrade/v2";
 
 /**
  * Format a date with the given format or return a `-`.
@@ -16,7 +15,7 @@ import { legacyParse } from "@date-fns/upgrade/v2";
 function formatDate(longDate, dateFormat = dateConstants.LONG_DATE_FORMAT) {
     const longDateInt = parseInt(longDate, 10);
     return longDateInt
-        ? format(legacyParse(new Date(longDateInt)), dateFormat)
+        ? lightFormat(toDate(new Date(longDateInt)), dateFormat)
         : dateConstants.EMPTY_DATE;
 }
 


### PR DESCRIPTION
Continuing with miscellaneous improvements as I dig into this stuff.

This removes the calls to `legacyParse` (updating to `toDate` -- the main difference is that `legacyParse` can take a string, but we're not passing it one, so it seems unnecessary), and switches to using `lightFormat` rather than `format`, which is the same but supports fewer of the weirder formatting things. I'm assuming we won't need things like quarters, day of year, etc, and this means we're importing a lot less of `date-fns`.