### PR TITLE
Create separate cjs and esm builds of the library

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,0 @@
-{
-  "presets": ["@babel/preset-env", "@babel/preset-react"],
-  "plugins": ["@babel/plugin-proposal-class-properties"]
-}

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+    presets: [
+        [
+            "@babel/preset-env",
+            {
+                modules: ["esm"].includes(process.env.BABEL_ENV)
+                    ? false
+                    : "commonjs",
+            },
+        ],
+        "@babel/preset-react",
+    ],
+    plugins: ["@babel/plugin-proposal-class-properties"],
+};

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "typescript": "^3.7.3"
     },
     "scripts": {
-        "build": "rm -rf dist && NODE_ENV=production babel src --out-dir dist --copy-files --ignore __tests__,spec.js,test.js,__snapshots__",
+        "build": "rm -rf dist && NODE_ENV=production BABEL_ENV=cjs babel src --out-dir dist/cjs --copy-files --ignore __tests__,spec.js,test.js,__snapshots__ && NODE_ENV=production BABEL_ENV=esm babel src --out-dir dist/esm --copy-files --ignore __tests__,spec.js,test.js,__snapshots__",
         "test": "react-scripts test",
         "eject": "react-scripts eject",
         "test:ci": "CI=true react-scripts test --env=jsdom --ci --testResultsProcessor ./node_modules/jest-junit-reporter",
@@ -92,8 +92,9 @@
         "react-select": "^2.0.0"
     },
     "description": "This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).",
-    "main": "dist/lib.js",
-    "module": "dist/lib.js",
+    "main": "dist/cjs/lib.js",
+    "module": "dist/esm/lib.js",
     "author": "discoenv",
+    "sideEffects": false,
     "license": "ISC"
 }


### PR DESCRIPTION
* this makes it so that webpack can see the ES module version of the library while trying to optimize
* set 'sideEffects' to false in package.json so it can be subject to tree-shaking (hopefully)

alongside some other fixes (which I'll put up as a separate PR), this can mean that we pull in dramatically less of ui-lib and of its dependencies in sonora