### PR TITLE
Change imports to ones nicer to webpack's tree-shaking

### DIFF
--- a/src/components/announcer/Announcer.js
+++ b/src/components/announcer/Announcer.js
@@ -16,7 +16,8 @@ import {
 } from "./AnnouncerConstants";
 import CloseIcon from "@material-ui/icons/Close";
 import IconButton from "@material-ui/core/IconButton";
-import { Snackbar, useTheme } from "@material-ui/core";
+import Snackbar from "@material-ui/core/Snackbar";
+import useTheme from "@material-ui/core/styles/useTheme";
 import Alert from "@material-ui/lab/Alert";
 
 function getTextColor(theme, severity) {

--- a/src/components/autocomplete/Autocomplete.js
+++ b/src/components/autocomplete/Autocomplete.js
@@ -13,7 +13,7 @@ import MenuItem from "@material-ui/core/MenuItem/index";
 import Select, { Creatable } from "react-select";
 import TextField from "@material-ui/core/TextField/index";
 import Typography from "@material-ui/core/Typography/index";
-import { withStyles } from "@material-ui/core/styles/index";
+import withStyles from "@material-ui/core/styles/withStyles";
 
 /**
  * @author aramsey

--- a/src/components/dotMenu/DotMenu.js
+++ b/src/components/dotMenu/DotMenu.js
@@ -22,7 +22,8 @@
 
 import React, { useState } from "react";
 
-import { Menu, IconButton } from "@material-ui/core";
+import Menu from "@material-ui/core/Menu";
+import IconButton from "@material-ui/core/IconButton";
 import MoreVertIcon from "@material-ui/icons/MoreVert";
 
 import build from "../../util/DebugIDUtil";

--- a/src/components/highlighter/Highlighter.js
+++ b/src/components/highlighter/Highlighter.js
@@ -1,7 +1,7 @@
 import React from "react";
 import Highlight from "react-highlighter";
 import PropTypes from "prop-types";
-import { withStyles } from "@material-ui/core/styles/index";
+import withStyles from "@material-ui/core/styles/withStyles";
 
 /**
  * @author aramsey

--- a/src/components/hyperlink/DEHyperlink.js
+++ b/src/components/hyperlink/DEHyperlink.js
@@ -1,7 +1,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import styles from "./style";
-import { withStyles } from "@material-ui/core/styles";
+import withStyles from "@material-ui/core/styles/withStyles";
 class DEHyperlink extends Component {
     render() {
         const { classes, text, onClick, ...custom } = this.props;

--- a/src/components/loading/LoadingMask.js
+++ b/src/components/loading/LoadingMask.js
@@ -8,7 +8,7 @@ import PropTypes from "prop-types";
 import LoadingOverlay from "react-loading-overlay";
 import palette from "../../util/CyVersePalette";
 import CircularProgress from "@material-ui/core/CircularProgress";
-import { withStyles } from "@material-ui/core/styles";
+import withStyles from "@material-ui/core/styles/withStyles";
 
 const style1 = (theme) => ({
     loading: {

--- a/src/components/quickLaunch/QuickLaunch.js
+++ b/src/components/quickLaunch/QuickLaunch.js
@@ -8,7 +8,7 @@ import PropTypes from "prop-types";
 import Chip from "@material-ui/core/Chip";
 import PublicIcon from "@material-ui/icons/Public";
 import LockIcon from "@material-ui/icons/Lock";
-import { withStyles } from "@material-ui/core/styles";
+import withStyles from "@material-ui/core/styles/withStyles";
 
 const styles1 = (theme) => ({
     chip: {

--- a/src/components/rating/Rate.js
+++ b/src/components/rating/Rate.js
@@ -9,7 +9,9 @@ import numeral from "numeral";
 import Rating from "@material-ui/lab/Rating";
 
 import IconButton from "@material-ui/core/IconButton";
-import { Tooltip, Typography, withStyles } from "@material-ui/core";
+import Tooltip from "@material-ui/core/Tooltip";
+import Typography from "@material-ui/core/Typography";
+import withStyles from "@material-ui/core/styles/withStyles";
 
 import DeleteIcon from "@material-ui/icons/Delete";
 

--- a/src/util/CyVerseTheme.js
+++ b/src/util/CyVerseTheme.js
@@ -1,4 +1,4 @@
-import { createMuiTheme } from "@material-ui/core/styles";
+import createMuiTheme from "@material-ui/core/styles/createMuiTheme";
 import palette from "./CyVersePalette";
 
 /**

--- a/src/util/ErrorExpansionPanel.js
+++ b/src/util/ErrorExpansionPanel.js
@@ -12,7 +12,7 @@ import ExpansionPanelDetails from "@material-ui/core/ExpansionPanelDetails";
 import PropTypes from "prop-types";
 import React from "react";
 import Typography from "@material-ui/core/Typography";
-import { withStyles } from "@material-ui/core/styles";
+import withStyles from "@material-ui/core/styles/withStyles";
 
 function ErrorExpansionPanel(props) {
     const { errMsg, username, userAgent, date, host, classes } = props;

--- a/src/util/ErrorHandler.js
+++ b/src/util/ErrorHandler.js
@@ -19,7 +19,7 @@ import ExpansionPanelSummary from "@material-ui/core/ExpansionPanelSummary";
 import ExpansionPanelDetails from "@material-ui/core/ExpansionPanelDetails";
 import PropTypes from "prop-types";
 import React, { Component } from "react";
-import { withStyles } from "@material-ui/core/styles";
+import withStyles from "@material-ui/core/styles/withStyles";
 
 class ErrorHandler extends Component {
     constructor(props) {

--- a/src/util/dialog/DEDialogHeader.js
+++ b/src/util/dialog/DEDialogHeader.js
@@ -16,7 +16,7 @@ import PropTypes from "prop-types";
 import DialogTitle from "@material-ui/core/DialogTitle";
 import Typography from "@material-ui/core/Typography";
 
-import { withStyles } from "@material-ui/core/styles";
+import withStyles from "@material-ui/core/styles/withStyles";
 
 import CloseIcon from "@material-ui/icons/Close";
 import IconButton from "@material-ui/core/IconButton";

--- a/src/util/table/DECheckbox.js
+++ b/src/util/table/DECheckbox.js
@@ -4,7 +4,7 @@
  * A regular MUI Checkbox but using the theme's primary color
  */
 import React from "react";
-import { Checkbox } from "@material-ui/core";
+import Checkbox from "@material-ui/core/Checkbox";
 
 function DECheckbox(props) {
     return <Checkbox color="primary" {...props} />;

--- a/src/util/table/TablePaginationActions.js
+++ b/src/util/table/TablePaginationActions.js
@@ -13,7 +13,7 @@ import FirstPageIcon from "@material-ui/icons/FirstPage";
 import KeyboardArrowLeft from "@material-ui/icons/KeyboardArrowLeft";
 import KeyboardArrowRight from "@material-ui/icons/KeyboardArrowRight";
 import LastPageIcon from "@material-ui/icons/LastPage";
-import { withStyles } from "@material-ui/core/styles";
+import withStyles from "@material-ui/core/styles/withStyles";
 
 const actionsStyles = (theme) => ({
     root: {


### PR DESCRIPTION
This, in combination with my other two PRs, nearly halves our first-load JS size in sonora by making it so much more of ui-lib gets tree-shaken away.

I'm not _completely_ sure why this is required along with the other PRs, but if folks aren't too bothered by the imports being a bit uglier, it's a definite improvement.