### PR TITLE
CORE-1352 Add readOnly support to FormCheckbox and FormSwitch

### DIFF
--- a/src/util/forms/FormCheckbox.js
+++ b/src/util/forms/FormCheckbox.js
@@ -10,9 +10,27 @@ import FormControl from "@material-ui/core/FormControl";
 import FormControlLabel from "@material-ui/core/FormControlLabel";
 import FormHelperText from "@material-ui/core/FormHelperText";
 
-// Apparently only necessary for FastField, but maybe more correct for "vanilla" Field as well.
-const onCheckboxChange = (setFieldValue, fieldName) => (event, checked) => {
-    setFieldValue(fieldName, checked);
+/**
+ * Creates an onChange function for use in a MUI Checkbox or Switch field,
+ * which will use the given `setFieldValue` function to update the value of the
+ * field with the given `fieldName`.
+ *
+ * @param {Function} setFieldValue Function that sets a value for `fieldName`.
+ * @param {string} fieldName The `name` of the checkbox field to change.
+ * @param {boolean} readOnly True if the field is read-only and should not change.
+ * Checkbox and switch fields with a `readonly` attribute on their `input`
+ * element will still allow the user to interact with it,
+ * calling its onChange function.
+ *
+ * @returns An onChange function for use in a MUI Checkbox or Switch field.
+ */
+const onCheckboxChange = (setFieldValue, fieldName, readOnly) => (
+    event,
+    checked
+) => {
+    if (!readOnly) {
+        setFieldValue(fieldName, checked);
+    }
 };
 
 const FormCheckbox = ({
@@ -30,7 +48,11 @@ const FormCheckbox = ({
                 control={
                     <Checkbox
                         checked={!!value}
-                        onChange={onCheckboxChange(setFieldValue, field.name)}
+                        onChange={onCheckboxChange(
+                            setFieldValue,
+                            field.name,
+                            custom.inputProps?.readOnly
+                        )}
                         {...field}
                         {...custom}
                     />

--- a/src/util/forms/FormSwitch.js
+++ b/src/util/forms/FormSwitch.js
@@ -30,7 +30,11 @@ const FormSwitch = (props) => {
                 control={
                     <Switch
                         checked={!!value}
-                        onChange={onCheckboxChange(setFieldValue, field.name)}
+                        onChange={onCheckboxChange(
+                            setFieldValue,
+                            field.name,
+                            custom.inputProps?.readOnly
+                        )}
                         {...field}
                         {...custom}
                     />

--- a/stories/FormFields.stories.js
+++ b/stories/FormFields.stories.js
@@ -46,6 +46,9 @@ export const TextField = () => {
     const helperText = text("Helper Text", "");
     const required = boolean("Required?", false);
     const loading = boolean("Loading Mask?", false);
+    const readOnly = boolean("Read Only?", false);
+
+    const inputProps = { readOnly };
 
     return (
         <TestForm required={required} initialValue="">
@@ -55,6 +58,7 @@ export const TextField = () => {
                 label={label}
                 helperText={helperText}
                 required={required}
+                inputProps={inputProps}
             />
         </TestForm>
     );
@@ -64,6 +68,9 @@ export const MultilineTextField = () => {
     const label = text("Label", "Multiline Text Field Label");
     const helperText = text("Helper Text", "");
     const required = boolean("Required?", false);
+    const readOnly = boolean("Read Only?", false);
+
+    const inputProps = { readOnly };
 
     return (
         <TestForm required={required} initialValue="">
@@ -73,6 +80,7 @@ export const MultilineTextField = () => {
                 label={label}
                 helperText={helperText}
                 required={required}
+                inputProps={inputProps}
             />
         </TestForm>
     );
@@ -82,6 +90,9 @@ export const IntegerField = () => {
     const label = text("Label", "Integer Field Label");
     const helperText = text("Helper Text", "");
     const required = boolean("Required?", false);
+    const readOnly = boolean("Read Only?", false);
+
+    const inputProps = { readOnly };
 
     return (
         <TestForm required={required} initialValue="">
@@ -91,6 +102,7 @@ export const IntegerField = () => {
                 label={label}
                 helperText={helperText}
                 required={required}
+                inputProps={inputProps}
             />
         </TestForm>
     );
@@ -100,6 +112,9 @@ export const NumberField = () => {
     const label = text("Label", "Number Field Label");
     const helperText = text("Helper Text", "");
     const required = boolean("Required?", false);
+    const readOnly = boolean("Read Only?", false);
+
+    const inputProps = { readOnly };
 
     return (
         <TestForm required={required} initialValue="">
@@ -109,6 +124,7 @@ export const NumberField = () => {
                 label={label}
                 helperText={helperText}
                 required={required}
+                inputProps={inputProps}
             />
         </TestForm>
     );
@@ -118,6 +134,9 @@ export const SelectField = () => {
     const label = text("Label", "Select Field Label");
     const helperText = text("Helper Text", "");
     const required = boolean("Required?", false);
+    const readOnly = boolean("Read Only?", false);
+
+    const inputProps = { readOnly };
 
     return (
         <TestForm required={required} initialValue="">
@@ -127,6 +146,7 @@ export const SelectField = () => {
                 label={label}
                 helperText={helperText}
                 required={required}
+                inputProps={inputProps}
             >
                 <MenuItem value={1}>One</MenuItem>
                 <MenuItem value={2}>Two</MenuItem>
@@ -139,6 +159,9 @@ export const SelectField = () => {
 export const Checkbox = () => {
     const label = text("Label", "Checkbox Label");
     const helperText = text("Helper Text", "");
+    const readOnly = boolean("Read Only?", false);
+
+    const inputProps = { readOnly };
 
     return (
         <TestForm initialValue={true}>
@@ -147,6 +170,7 @@ export const Checkbox = () => {
                 name="test_field"
                 label={label}
                 helperText={helperText}
+                inputProps={inputProps}
             />
         </TestForm>
     );
@@ -155,6 +179,9 @@ export const Checkbox = () => {
 export const Switch = () => {
     const label = text("Label", "Switch Label");
     const helperText = text("Helper Text", "");
+    const readOnly = boolean("Read Only?", false);
+
+    const inputProps = { readOnly };
 
     return (
         <TestForm initialValue={true}>
@@ -163,6 +190,7 @@ export const Switch = () => {
                 name="test_field"
                 label={label}
                 helperText={helperText}
+                inputProps={inputProps}
             />
         </TestForm>
     );
@@ -171,6 +199,9 @@ export const Switch = () => {
 export const Timestamp = () => {
     const label = text("Label", "Timestamp Label");
     const helperText = text("Helper Text", "");
+    const readOnly = boolean("Read Only?", false);
+
+    const inputProps = { readOnly };
 
     return (
         <TestForm
@@ -184,6 +215,7 @@ export const Timestamp = () => {
                 name="test_field"
                 label={label}
                 helperText={helperText}
+                inputProps={inputProps}
             />
         </TestForm>
     );


### PR DESCRIPTION
This is required for preventing users from changing the value of our `FormCheckbox` and `FormSwitch` fields that should be read-only (when editing a public app, for example); since a native `checkbox` input field with a `readonly` attribute will still allow the user to interact with it (see https://stackoverflow.com/questions/155291/can-html-checkboxes-be-set-to-readonly for example), calling our `onChange` function that will change its value in the form.

This PR also updates all form field stories with a "Read Only" knob.