### PR TITLE
CORE-1418 Enable dot menu to be btn w/ text or icon

### DIFF
--- a/src/components/dotMenu/DotMenu.js
+++ b/src/components/dotMenu/DotMenu.js
@@ -4,6 +4,10 @@
  *  A component which displays 3 vertical dots, which when
  *  clicked will display a menu.
  *
+ *  For a large screen, the users will see a Button with the 3 dots icon, plus
+ *  the supplied button text.
+ *  For a smaller screen, or if no text is provided, users will only see the icon.
+ *
  *  MenuItems should be passed into the render prop which in turn
  *  will provide a function for closing the menu.
  *
@@ -22,15 +26,29 @@
 
 import React, { useState } from "react";
 
-import { Menu, IconButton } from "@material-ui/core";
+import {
+    Button,
+    IconButton,
+    Menu,
+    useMediaQuery,
+    useTheme,
+} from "@material-ui/core";
 import MoreVertIcon from "@material-ui/icons/MoreVert";
 
 import build from "../../util/DebugIDUtil";
 
 function DotMenu(props) {
-    const { baseId, render, ButtonProps, MenuProps } = props;
+    const {
+        baseId,
+        render,
+        ButtonProps,
+        buttonText,
+        iconOnlyBreakpoint = "xs",
+        MenuProps,
+    } = props;
     const [anchorEl, setAnchorEl] = useState(null);
     const open = Boolean(anchorEl);
+    const theme = useTheme();
 
     const handleDotMenuClick = (event) => {
         setAnchorEl(event.currentTarget);
@@ -42,18 +60,26 @@ function DotMenu(props) {
 
     let menuId = build(baseId, "moreMenu");
 
+    const isIconButton =
+        useMediaQuery(theme.breakpoints.down(iconOnlyBreakpoint)) || !buttonText;
+
+    const Component = isIconButton ? IconButton : Button;
+
     return (
         <>
-            <IconButton
+            <Component
                 id={build(baseId, "dotMenuIcon")}
                 aria-controls={menuId}
                 aria-haspopup="true"
                 onClick={handleDotMenuClick}
                 size="small"
+                variant={isIconButton ? null : "outlined"}
+                color={isIconButton ? "default" : "primary"}
+                {...isIconButton ? null : { startIcon: <MoreVertIcon /> }}
                 {...ButtonProps}
             >
-                <MoreVertIcon />
-            </IconButton>
+                {isIconButton ? <MoreVertIcon /> : buttonText}
+            </Component>
             <Menu
                 id={menuId}
                 anchorEl={anchorEl}

--- a/stories/DotMenu.stories.js
+++ b/stories/DotMenu.stories.js
@@ -3,41 +3,54 @@ import { MenuItem } from "@material-ui/core";
 
 import DotMenu from "../src/components/dotMenu/DotMenu";
 
+const getMenuItems = (onClose) => [
+    <MenuItem
+        key={1}
+        onClick={() => {
+            onClose();
+            console.log("Clicked Item 1");
+        }}
+    >
+        Item 1
+    </MenuItem>,
+    <MenuItem
+        key={2}
+        onClick={() => {
+            onClose();
+            console.log("Clicked Item 2");
+        }}
+    >
+        Item 2
+    </MenuItem>,
+    <MenuItem
+        key={3}
+        onClick={() => {
+            onClose();
+            console.log("Clicked Item 3");
+        }}
+    >
+        Item 3
+    </MenuItem>,
+];
+
 export const DotMenuTest = () => {
     return (
         <DotMenu
             baseId="sampleDotMenu"
-            render={(onClose) => [
-                <MenuItem
-                    key={1}
-                    onClick={() => {
-                        onClose();
-                        console.log("Clicked Item 1");
-                    }}
-                >
-                    Item 1
-                </MenuItem>,
-                <MenuItem
-                    key={2}
-                    onClick={() => {
-                        onClose();
-                        console.log("Clicked Item 2");
-                    }}
-                >
-                    Item 2
-                </MenuItem>,
-                <MenuItem
-                    key={3}
-                    onClick={() => {
-                        onClose();
-                        console.log("Clicked Item 3");
-                    }}
-                >
-                    Item 3
-                </MenuItem>,
-            ]}
+            render={getMenuItems}
         />
     );
 };
+
+export const DotMenuWithText = () => {
+    return (
+        <DotMenu
+            baseId="sampleDotMenu"
+            render={getMenuItems}
+            buttonText="More Actions"
+        />
+    );
+};
+
 
 export default { title: "DotMenu" };


### PR DESCRIPTION
I went with the primary color when it's a Button with text so it doesn't stick out from the other toolbar buttons:
![image](https://user-images.githubusercontent.com/8909156/118058279-b0c75900-b342-11eb-9b0f-fb90a1cb144c.png)

But then it goes back to the normal gray color IconButton when on a smaller screen or if it's a row dot menu, for example.